### PR TITLE
Use switch-to-buffer instead helm-switch-to-buffer

### DIFF
--- a/helm-mt.el
+++ b/helm-mt.el
@@ -71,7 +71,7 @@
                                   (helm-mt/terminal-buffers)
                                   (list ""))))
         (action . (("Switch to terminal buffer" . (lambda (candidate)
-                                                    (helm-switch-to-buffer candidate)))
+                                                    (switch-to-buffer candidate)))
                    ("Exit marked terminals" 'helm-mt/delete-marked-terms)))))
  
 


### PR DESCRIPTION
In emacs-helm/helm, in commit 1b48c0c2f01b9b1a02b53ce5cb619d35f61d6762
was removed  helm-switch-to-buffer,  instead use  switch-to-buffer
function
