### PR TITLE
Added in support for multiple terminal modes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Invoke `helm-mt` and bind it to a keyboard shortcut
 (require 'helm-mt)
 (global-set-key (kbd "C-x t") 'helm-mt)
 ```
+
+If you would like to have helm-mt run when you do "M-x term" or "M-x shell",
+then put this in your init file:
+
+```
+(helm-mt/wrap-shells t)
+```
+
+To deactivate the advice pass "nil" instead of "t".

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -17,7 +17,8 @@
 
 ;; Author: Didier Deshommes <dfdeshom@gmail.com>
 ;; URL: https://github.com/dfdeshom/helm-mt
-;; Version: 0.4
+;; Version: 20150302.1804
+;; X-Original-Version: 0.4
 ;; Package-Requires: ((emacs "24") (helm "0.0") (multi-term "0.0") (cl-lib "0.5"))
 ;; Keywords: helm multi-term
 
@@ -38,16 +39,23 @@
 
 (defvar helm-marked-buffer-name)
 
+(defvar helm-mt/all-terminal-modes '(term-mode shell-mode))
+
 (defun helm-mt/terminal-buffers ()
   "Filter for buffers that are terminals only."
   (cl-loop for buf in (buffer-list)
-           if (eq 'term-mode (buffer-local-value 'major-mode buf))
+           if (member (buffer-local-value 'major-mode buf) helm-mt/all-terminal-modes)
            collect (buffer-name buf)) )
 
-(defun helm-mt/launch-term (name)
-  "Create new terminal in a buffer called NAME."
-  (multi-term)
-  (rename-buffer (format "*terminal<%s>*" name)))
+(defun helm-mt/launch-term (name mode)
+  "Create new terminal in a buffer called NAME using optional MODE."
+  (message (format "MT Launch name %s" name))
+  (case mode
+	('term
+	 (multi-term)
+	 (rename-buffer (format "*terminal<%s>*" name)))
+	('shell
+	 (shell (format "*shell<%s>*" name)))))
 
 (defun helm-mt/delete-marked-terms (ignored)
   "Delete marked terminals.  The IGNORED argument is not used."
@@ -78,8 +86,10 @@
 (defvar helm-mt/term-source-terminal-not-found
   '((name . "Launch a new terminal")
     (dummy)
-    (action . (("Launch new terminal" . (lambda (candidate)
-                                          (helm-mt/launch-term candidate)))))))
+    (action . (("Launch new term" . (lambda (candidate)
+                                          (helm-mt/launch-term candidate 'term)))
+			   ("Launch new shell" . (lambda (candidate)
+									   (helm-mt/launch-term candidate 'shell)))))))
 
 ;;;###autoload
 (defun helm-mt ()

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -51,10 +51,10 @@
   "Create new terminal in a buffer called NAME using optional MODE."
   (message (format "MT Launch name %s" name))
   (case mode
-	('term
+	('term-mode
 	 (multi-term)
 	 (rename-buffer (format "*terminal<%s>*" name)))
-	('shell
+	('shell-mode
 	 (shell (format "*shell<%s>*" name)))))
 
 (defun helm-mt/delete-marked-terms (ignored)
@@ -81,23 +81,23 @@
         (action . (("Switch to terminal buffer" . (lambda (candidate)
                                                     (switch-to-buffer candidate)))
                    ("Exit marked terminals" 'helm-mt/delete-marked-terms)))))
- 
 
-(defvar helm-mt/term-source-terminal-not-found
-  '((name . "Launch a new terminal")
-    (dummy)
-    (action . (("Launch new term" . (lambda (candidate)
-                                          (helm-mt/launch-term candidate 'term)))
-			   ("Launch new shell" . (lambda (candidate)
-									   (helm-mt/launch-term candidate 'shell)))))))
+(defun helm-mt/term-source-terminal-not-found ()
+  `((name . "Launch a new terminal")
+	(dummy)
+	(action . ,(mapcar (lambda (mode)
+						  `(,(format "Launch new %s" mode) . 
+							(lambda (candidate)
+								(helm-mt/launch-term candidate (quote ,mode)))))
+					  helm-mt/all-terminal-modes))))
 
 ;;;###autoload
 (defun helm-mt ()
   "Custom helm buffer for terminals only."
   (interactive)
   (let ((sources
-        '(helm-mt/term-source-terminals
-          helm-mt/term-source-terminal-not-found)))
+		 `(helm-mt/term-source-terminals
+		   ,(helm-mt/term-source-terminal-not-found))))
     (helm :sources sources
           :buffer "*helm-mt*")))
 


### PR DESCRIPTION
You can type the name of a new shell and hit tab to choose between "shell" and "term" mode.

It will also list all buffers with major mode of shell or term.
