### PR TITLE
Upgrade to new helm API

### DIFF
--- a/helm-mt.el
+++ b/helm-mt.el
@@ -42,8 +42,6 @@
   "Open helm-mt."
   :prefix "helm-mt/" :group 'helm)
 
-(defvar helm-marked-buffer-name)
-
 (defvar helm-mt/all-terminal-modes '(term-mode shell-mode)
   "If a buffer has a major mode in this list, helm-mt will list it as an option.
 The order of the modes controls which is the default action in the helm-mt UI.")
@@ -76,20 +74,20 @@ The order of the modes controls which is the default action in the helm-mt UI.")
     ('shell-mode
      (shell (helm-mt/unique-buffer-name name 'shell-mode)))))
 
-(defun helm-mt/delete-marked-terms (ignored)
-  "Delete marked terminals.  The IGNORED argument is not used."
-  (let* ((buffers (helm-marked-candidates :with-wildcard t))
-         (len (length buffers)))
-    (with-helm-display-marked-candidates
-      helm-marked-buffer-name
-      ;; kill the process in the buffer
-      ;; then delete buffer, to avoid confirmation questions
-      (cl-dolist (b buffers)
-        (delete-process b)
-        (kill-buffer b))
-      ;; restore orignal window configuration
-      (balance-windows (selected-frame))
-      (message "%s Terminals deleted" len))))
+(defun helm-mt/delete-marked-terms (_ignored)
+  "Delete marked terminals.
+The _IGNORED argument is not used."
+  (let* ((bufs (helm-marked-candidates))
+         (killed-bufs (cl-count-if 'helm-mt/delete-term bufs)))
+    (with-helm-buffer
+      (setq helm-marked-candidates nil
+            helm-visible-mark-overlays nil))
+    (message "Deleted %s terminal(s)" killed-bufs)))
+
+(defun helm-mt/delete-term (name)
+  "Delete terminal NAME."
+  (delete-process name)
+  (kill-buffer name))
 
 (defun helm-mt/helper-auto-terminal ()
   "Launch a term with the current directory as the name."

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -44,13 +44,13 @@
 
 (defvar helm-mt/all-terminal-modes '(term-mode shell-mode)
   "If a buffer has a major mode in this list, helm-mt will list it as an option.
-The order of the modes controls which is the default action in the helm-mt UI." )
+The order of the modes controls which is the default action in the helm-mt UI.")
 
 (defun helm-mt/terminal-buffers ()
   "Filter for buffers that are terminals only."
   (cl-loop for buf in (buffer-list)
            if (member (buffer-local-value 'major-mode buf) helm-mt/all-terminal-modes)
-           collect (buffer-name buf)) )
+           collect (buffer-name buf)))
 
 (defun helm-mt/unique-buffer-name (name mode)
   "Unique buffer from NAME and MODE."
@@ -58,14 +58,12 @@ The order of the modes controls which is the default action in the helm-mt UI." 
     ('term-mode
      (generate-new-buffer-name (format "*terminal<%s>*" name)))
     ('shell-mode
-     (generate-new-buffer-name (format "*shell<%s>*" name))))
-  )
+     (generate-new-buffer-name (format "*shell<%s>*" name)))))
 
 (defun helm-mt/new-term (name)
   "Create terminal NAME."
   (multi-term)
-  (rename-buffer name)
-  )
+  (rename-buffer name))
 
 (defun helm-mt/launch-term (name mode)
   "Create new terminal in a buffer called NAME using optional MODE."
@@ -74,7 +72,7 @@ The order of the modes controls which is the default action in the helm-mt UI." 
     ('term-mode
      (helm-mt/new-term (helm-mt/unique-buffer-name name 'term-mode)))
     ('shell-mode
-     (shell (helm-mt/unique-buffer-name name 'shell-mode) ))))
+     (shell (helm-mt/unique-buffer-name name 'shell-mode)))))
 
 (defun helm-mt/delete-marked-terms (ignored)
   "Delete marked terminals.  The IGNORED argument is not used."
@@ -82,41 +80,37 @@ The order of the modes controls which is the default action in the helm-mt UI." 
          (len (length buffers)))
     (with-helm-display-marked-candidates
       helm-marked-buffer-name
-          ;; kill the process in the buffer
-          ;; then delete buffer, to avoid confirmation questions
-        (cl-dolist (b buffers)
-          (delete-process b)
-          (kill-buffer b))
-        ;; restore orignal window configuration
-        (balance-windows (selected-frame))
-        (message "%s Terminals deleted" len))))
+      ;; kill the process in the buffer
+      ;; then delete buffer, to avoid confirmation questions
+      (cl-dolist (b buffers)
+        (delete-process b)
+        (kill-buffer b))
+      ;; restore orignal window configuration
+      (balance-windows (selected-frame))
+      (message "%s Terminals deleted" len))))
 
 (defun helm-mt/helper-auto-terminal ()
   "Launch a term with the current directory as the name."
   (let* ((name (replace-regexp-in-string  (regexp-quote "Directory ") "" (pwd)))
          (terminal_name (helm-mt/unique-buffer-name name 'term-mode)))
-    
-    (helm-mt/new-term terminal_name)
-  
-    )
-  )
+    (helm-mt/new-term terminal_name)))
 
 (defun helm-mt/auto-terminal ()
   "Launch a term with the current directory as the name."
   (interactive)
   (helm-mt/helper-auto-terminal)
-  
-                                        ;(helm-keyboard-quit)
-                                        ;(helm-exit-minibuffer)
-                                        ;(exit-minibuffer)
-;  (helm-quit-and-execute-action 'helm-mt/helper-launch-term-with-named-dir)
-    )
+  ;;(helm-keyboard-quit)
+  ;;(helm-exit-minibuffer)
+  ;;(exit-minibuffer)
+  ;;(helm-quit-and-execute-action 'helm-mt/helper-launch-term-with-named-dir)
+  )
 
 (defvar helm-mt/keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map helm-map)
     (define-key map (kbd "C-c n") 'helm-mt/auto-terminal)
-    (delq nil map)) "Keymap for helm-mt.")
+    (delq nil map))
+  "Keymap for helm-mt.")
 
 
 (defun helm-mt/term-source-terminals ()
@@ -133,11 +127,11 @@ The order of the modes controls which is the default action in the helm-mt UI." 
 
 (defun helm-mt/shell-advice (orig-fun &rest args)
   "Advice that has helm-mt run when invoking `M-x shell` or `M-x term`.
-Agument ORIG-FUN is the original function, ARGS are its arguments"
+Agument ORIG-FUN is the original function, ARGS are its arguments."
   (message "wrapping shell with helm-mt")
   (if (called-interactively-p 'interactive)
-	  (call-interactively 'helm-mt)
-	(apply orig-fun args)))
+      (call-interactively 'helm-mt)
+    (apply orig-fun args)))
 
 ;;;###autoload
 (defun helm-mt/wrap-shells (onoff)
@@ -146,18 +140,17 @@ This routes to helm-mt UI instead of launching a new shell/terminal.
 If ONOFF is t, activate the advice and if nil, remove it."
   (interactive)
   (dolist (mode helm-mt/all-terminal-modes)
-	(let ((fun (intern (replace-regexp-in-string  (regexp-quote "-mode") "" (symbol-name mode)))))
-	  (if onoff
-		  (eval
-		   `(add-function :around (symbol-function (quote ,fun)) #'helm-mt/shell-advice))
-		(eval `(advice-remove (quote ,fun) #'helm-mt/shell-advice))))))
+    (let ((fun (intern (replace-regexp-in-string (regexp-quote "-mode") "" (symbol-name mode)))))
+      (if onoff
+          (eval
+           `(add-function :around (symbol-function (quote ,fun)) #'helm-mt/shell-advice))
+        (eval `(advice-remove (quote ,fun) #'helm-mt/shell-advice))))))
 
 (defun helm-mt/dir-name ()
   "Get the name of the current directory only, not the full name."
   (car (last  (split-string
-           (replace-regexp-in-string
-            (regexp-quote "Directory ") "" (pwd)) "/") 2))
-  )
+               (replace-regexp-in-string
+                (regexp-quote "Directory ") "" (pwd)) "/") 2)))
 
 ;;;###autoload
 (defun helm-mt ()
@@ -172,9 +165,8 @@ If ONOFF is t, activate the advice and if nil, remove it."
                                     (helm-mt/launch-term candidate (quote ,mode)))))
                               helm-mt/all-terminal-modes)))))
     (helm :sources sources
-                                        ;:input (helm-mt/dir-name)
+          ;;:input (helm-mt/dir-name)
           :buffer "*helm-mt*")))
 
 (provide 'helm-mt)
-
 ;;; helm-mt.el ends here

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -86,7 +86,8 @@ The _IGNORED argument is not used."
 
 (defun helm-mt/delete-term (name)
   "Delete terminal NAME."
-  (delete-process name)
+  (if (get-buffer-process name)
+      (delete-process name))
   (kill-buffer name))
 
 (defun helm-mt/helper-auto-terminal ()

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -112,7 +112,8 @@ The _IGNORED argument is not used."
     (delq nil map))
   "Keymap for helm-mt.")
 
-(defvar helm-mt/term-source-terminals
+(defun helm-mt/term-source-terminals ()
+  "Helm source with candidates for all terminal buffers."
   (helm-build-sync-source
       "Terminals"
     :candidates (lambda () (or
@@ -126,7 +127,8 @@ The _IGNORED argument is not used."
              (lambda (_ignored)
                (helm-mt/delete-marked-terms _ignored)))))
 
-(defvar helm-mt/term-source-terminal-not-found
+(defun helm-mt/term-source-terminal-not-found ()
+  "Dummy helm source to launch a new terminal."
   (helm-build-dummy-source
       "Launch a new terminal"
     :action (apply 'helm-make-actions
@@ -162,8 +164,8 @@ If ONOFF is t, activate the advice and if nil, remove it."
 (defun helm-mt ()
   "Custom helm buffer for terminals only."
   (interactive)
-  (helm :sources '(helm-mt/term-source-terminals
-                   helm-mt/term-source-terminal-not-found)
+  (helm :sources `(,(helm-mt/term-source-terminals)
+                   ,(helm-mt/term-source-terminal-not-found))
         :keymap helm-mt/keymap
         :buffer "*helm mt*"))
 

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -139,7 +139,7 @@ The _IGNORED argument is not used."
 
 (defun helm-mt/shell-advice (orig-fun &rest args)
   "Advice that has helm-mt run when invoking `M-x shell` or `M-x term`.
-Agument ORIG-FUN is the original function, ARGS are its arguments."
+Argument ORIG-FUN is the original function, ARGS are its arguments."
   (message "wrapping shell with helm-mt")
   (if (called-interactively-p 'interactive)
       (call-interactively 'helm-mt)

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -1,6 +1,12 @@
-;;; helm-mt.el --- helm multi-term management. -*- lexical-binding: t -*-
+;;; helm-mt.el --- helm multi-term management -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015 Didier Deshommes <dfdeshom@gmail.com>
+;; Copyright (C) 2015, 2016 Didier Deshommes <dfdeshom@gmail.com>
+
+;; Author: Didier Deshommes <dfdeshom@gmail.com>
+;; URL: https://github.com/dfdeshom/helm-mt
+;; Version: 0.6
+;; Package-Requires: ((emacs "24") (helm "0.0") (multi-term "0.0") (cl-lib "0.5"))
+;; Keywords: helm multi-term
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -15,22 +21,16 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; Author: Didier Deshommes <dfdeshom@gmail.com>
-;; URL: https://github.com/dfdeshom/helm-mt
-;; Version: 0.6
-;; Package-Requires: ((emacs "24") (helm "0.0") (multi-term "0.0") (cl-lib "0.5"))
-;; Keywords: helm multi-term
-
 ;;; Commentary:
 
-;; Create and delete multi-term terminals easily with Helm
-
-;; A call to `helm-mt` will show a list of running terminal sessions
-;; by examining buffers with major mode `term-mode` or `shell-mode`.
-;; From there, you should be able to create, delete or switch over to existing
-;; terminal buffers
+;; Create and delete multi-term terminals easily with Helm.  A call to
+;; `helm-mt` will show a list of running terminal sessions by
+;; examining buffers with major mode `term-mode` or `shell-mode`.
+;; From there, you should be able to create, delete or switch over to
+;; existing terminal buffers.
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'helm)
 (require 'helm-utils)

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -158,12 +158,6 @@ If ONOFF is t, activate the advice and if nil, remove it."
            `(add-function :around (symbol-function (quote ,fun)) #'helm-mt/shell-advice))
         (eval `(advice-remove (quote ,fun) #'helm-mt/shell-advice))))))
 
-(defun helm-mt/dir-name ()
-  "Get the name of the current directory only, not the full name."
-  (car (last  (split-string
-               (replace-regexp-in-string
-                (regexp-quote "Directory ") "" (pwd)) "/") 2)))
-
 ;;;###autoload
 (defun helm-mt ()
   "Custom helm buffer for terminals only."


### PR DESCRIPTION
Upgrade to new helm API, try to use helper functions provided by helm (see #9).
- It seems that the "Exit marked terminals" action was broken too, so I simplified and hardened it by stealing from `helm-buffers.el` :)
- I also took the liberty to clean up whitespace and comments a bit, hope that's ok.
- I went with `defvar` vs `defun` for the helm sources (ie. against your advice in the related issue) to keep things as "helm-like" as possible. I felt like that's easier to grasp on first read?

Please note that this is only tested to "work on my machine".
