### PR TITLE
Simplify code, add a bit of new functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,18 @@
 [![MELPA Stable](http://stable.melpa.org/packages/helm-mt-badge.svg)](http://stable.melpa.org/#/helm-mt)
 
 # helm-mt
-Helm bindings for managing multi-term terminals
+Helm bindings for managing [`multi-term`](https://www.emacswiki.org/emacs/MultiTerm) terminals as well as shells.
 
-Create and delete terminals in `term` or `shell` mode  easily with Helm
+A call to `helm-mt` will show a list of terminal sessions managed by `multi-term` as well as buffers with major mode `shell-mode`.
 
-A call to `helm-mt` will show a list of running terminal sessions
-by examining buffers with major mode `term-mode` or `shell-mode`.  From there, you
-should be able to create, delete or switch over to existing
-terminal buffers
+From there, you are able to create, delete or switch over to existing terminal buffers.
 
 ![helm-mt](mt.gif)
 
 # Setup
-Invoke `helm-mt` and bind it to a keyboard shortcut
+Invoke `helm-mt` and bind it to a keyboard shortcut:
 
-```
+```elisp
 (require 'helm-mt)
 (global-set-key (kbd "C-x t") 'helm-mt)
 ```
-
-If you would like to have `helm-mt` run when you do `M-x term` or `M-x shell`,
-then put this in your init file:
-
-```
-(helm-mt/wrap-shells t)
-```
-
-To deactivate the advice pass `nil` instead of `t`.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Invoke `helm-mt` and bind it to a keyboard shortcut:
 (require 'helm-mt)
 (global-set-key (kbd "C-x t") 'helm-mt)
 ```
+
+If you would like to run `helm-mt` when you do `M-x term` or `M-x shell`, then put this in your init file:
+
+```elisp
+(helm-mt/reroute-terminal-functions t)
+```
+
+To deactivate this behavior again, pass `nil` instead of `t`.

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -23,9 +23,10 @@
 
 ;;; Commentary:
 
-;; Create and delete multi-term terminals easily with Helm.  A call to
-;; `helm-mt' will show a list of terminal sessions managed by
-;; multi-term.  From there, you are able to create, delete or switch
+;; Helm bindings for managing `multi-term' terminals as well as
+;; shells.  A call to `helm-mt` will show a list of terminal sessions
+;; managed by `multi-term` as well as buffers with major mode
+;; `shell-mode`.  From there, you are able to create, delete or switch
 ;; over to existing terminal buffers.
 
 ;;; Code:

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -133,7 +133,6 @@ launched process."
                                       (if (string-equal helm-pattern "")
                                           (list '("Named after terminal working directory (default)" . "%cwd"))
                                         (list helm-pattern)))
-    :matchplugin nil
     :match 'identity
     :volatile t
     :action (apply 'helm-make-actions

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -39,86 +39,106 @@
 (defvar helm-mt/keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map helm-map)
-    (define-key map (kbd "M-D") 'helm-mt/helm-buffer-run-delete-terms)
+    (define-key map (kbd "M-D") 'helm-mt/helm-buffer-run-delete-terminals)
     (delq nil map))
   "Keymap for `helm-mt'.")
 
-(defun helm-mt/launch-term (name prefix)
-  "Launch a new terminal in a buffer called NAME.
-PREFIX is passed on to `multi-term' as a prefix argument."
-  (setq current-prefix-arg prefix)
-  (call-interactively 'multi-term)
-  (rename-buffer (generate-new-buffer-name (format "*terminal<%s>*" name))))
+(defun helm-mt/terminal-buffers ()
+  "Filter for buffers that are terminals only.
+Includes buffers managed by `multi-term' (excludes dedicated term
+buffers) and buffers in `shell-mode'."
+  (cl-loop for buf in (buffer-list)
+           if (or (member buf multi-term-buffer-list)
+                  (eq (buffer-local-value 'major-mode buf) 'shell-mode))
+           collect (buffer-name buf)))
 
-(defun helm-mt/delete-marked-terms (ignored)
+(defun helm-mt/launch-terminal (name prefix mode)
+  "Launch a terminal in a new buffer.
+NAME is the desired name of the buffer, which will be prefixed with
+mode and made unique.  PREFIX is passed on to the function that
+creates the terminal as a prefix argument.  MODE is either 'term or
+'shell."
+  (setq current-prefix-arg prefix)
+  (cl-case mode
+    ('term
+     (setq name-prefix "terminal")
+     (call-interactively 'multi-term))
+    ('shell
+     (setq name-prefix "shell")
+     (call-interactively 'shell)))
+  (rename-buffer (generate-new-buffer-name (format "*%s<%s>*" name-prefix name))))
+
+(defun helm-mt/delete-marked-terminals (ignored)
   "Delete marked terminals.
 Argument IGNORED is not used."
   (let* ((bufs (helm-marked-candidates))
-         (killed-bufs (cl-count-if 'helm-mt/delete-term bufs)))
+         (killed-bufs (cl-count-if 'helm-mt/delete-terminal bufs)))
     (with-helm-buffer
       (setq helm-marked-candidates nil
             helm-visible-mark-overlays nil))
     (message "Deleted %s terminal(s)" killed-bufs)))
 
-(defun helm-mt/delete-term (name)
+(defun helm-mt/delete-terminal (name)
   "Delete terminal NAME."
   (if (get-buffer-process name)
       (delete-process name))
   (kill-buffer name))
 
-(defun helm-mt/helm-buffer-run-delete-terms ()
-  "Run delete terms action from `helm-mt' source list."
+(defun helm-mt/helm-buffer-run-delete-terminals ()
+  "Run 'delete marked terminals' action from `helm-mt' source list."
   (interactive)
   (with-helm-alive-p
-    (helm-exit-and-execute-action 'helm-mt/delete-marked-terms)))
-(put 'helm-mt/helm-buffer-run-delete-terms 'helm-only t)
+    (helm-exit-and-execute-action 'helm-mt/delete-marked-terminals)))
+(put 'helm-mt/helm-buffer-run-delete-terminals 'helm-only t)
 
-(defun helm-mt/term-source-terminals ()
-  "Helm source with candidates for all terminal buffers managed by `multi-term'."
+(defun helm-mt/source-terminals ()
+  "Helm source with candidates for all terminal buffers."
   (helm-build-sync-source
       "Terminals"
     :candidates (lambda () (or
-                            (mapcar 'buffer-name multi-term-buffer-list)
+                            (helm-mt/terminal-buffers)
                             (list "")))
     :action (helm-make-actions
              "Switch to terminal"
              (lambda (candidate)
                (switch-to-buffer candidate))
-             "Exit marked terminal(s) `M-D'"
+             "Delete marked terminal(s) `M-D'"
              (lambda (ignored)
-               (helm-mt/delete-marked-terms ignored)))))
+               (helm-mt/delete-marked-terminals ignored)))))
 
-(defun helm-mt/term-source-terminal-not-found (prefix)
+(defun helm-mt/source-terminal-not-found (prefix)
   "Helm source to launch a new terminal.
-PREFIX is passed on to `helm-mt/launch-term'.
-Defaults to a terminal with a unique name derived from the `default-directory'."
-  (let* ((default-display "Named after current directory (default)")
-         (default-real (generate-new-buffer-name (expand-file-name default-directory)))
-         (default `(,default-display . ,default-real)))
+PREFIX is passed on to `helm-mt/launch-terminal'.  Defaults to a
+terminal with a unique name derived from the `default-directory'."
+  (let ((default-display "Named after current directory (default)")
+        (default-real (generate-new-buffer-name (expand-file-name default-directory))))
     (helm-build-sync-source
         "Launch a new terminal"
       :candidates '("dummy")
       :filtered-candidate-transformer (lambda (candidates _source)
                                         (if (string-equal helm-pattern "")
-                                            (list default)
+                                            (list `(,default-display . ,default-real))
                                           (list helm-pattern)))
       :matchplugin nil
       :match 'identity
       :volatile t
-      :action (helm-make-actions
-               "Launch new terminal"
-               (lambda (candidate)
-                 (if (string-equal candidate (car default))
-                     (setq candidate (cdr default)))
-                 (helm-mt/launch-term candidate prefix))))))
+      :action (apply 'helm-make-actions
+                     (apply 'append
+                            (mapcar (lambda (mode)
+                                      (list (format "Launch new %s" mode)
+                                            `(lambda (candidate)
+                                               (if (string-equal candidate ,default-display)
+                                                   (setq candidate ,default-real))
+                                               (helm-mt/launch-terminal candidate ,prefix (quote ,mode)))))
+                                    (list 'term 'shell)))))))
 
 ;;;###autoload
 (defun helm-mt (prefix)
   "Custom helm buffer for terminals only.
 PREFIX is passed on to `helm-mt/term-source-terminal-not-found'."
   (interactive "P")
-  (helm :sources `(,(helm-mt/term-source-terminals)
-                   ,(helm-mt/term-source-terminal-not-found prefix))
+  (helm :sources `(,(helm-mt/source-terminals)
+                   ,(helm-mt/source-terminal-not-found prefix))
         :keymap helm-mt/keymap
         :buffer "*helm mt*"))
 

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -39,6 +39,7 @@
 (defvar helm-mt/keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map helm-map)
+    (define-key map (kbd "M-D") 'helm-mt/helm-buffer-run-delete-terms)
     (delq nil map))
   "Keymap for `helm-mt'.")
 
@@ -65,6 +66,13 @@ Argument IGNORED is not used."
       (delete-process name))
   (kill-buffer name))
 
+(defun helm-mt/helm-buffer-run-delete-terms ()
+  "Run delete terms action from `helm-mt' source list."
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-mt/delete-marked-terms)))
+(put 'helm-mt/helm-buffer-run-delete-terms 'helm-only t)
+
 (defun helm-mt/term-source-terminals ()
   "Helm source with candidates for all terminal buffers managed by `multi-term'."
   (helm-build-sync-source
@@ -76,7 +84,7 @@ Argument IGNORED is not used."
              "Switch to terminal"
              (lambda (candidate)
                (switch-to-buffer candidate))
-             "Exit marked terminal(s)"
+             "Exit marked terminal(s) `M-D'"
              (lambda (ignored)
                (helm-mt/delete-marked-terms ignored)))))
 

--- a/helm-mt.el
+++ b/helm-mt.el
@@ -133,8 +133,26 @@ terminal with a unique name derived from the `default-directory'."
                                                (helm-mt/launch-terminal candidate ,prefix (quote ,mode)))))
                                     (list 'term 'shell)))))))
 
+(defun helm-mt/reroute-function (orig-fun &rest args)
+  "Advise a function to run `helm-mt' instead when called interactively.
+Argument ORIG-FUN is the original function, ARGS are its arguments."
+  (if (called-interactively-p 'interactive)
+      (progn
+        (message "Rerouting to `helm-mt'")
+        (helm-mt))
+    (apply orig-fun args)))
+
 ;;;###autoload
-(defun helm-mt (prefix)
+(defun helm-mt/reroute-terminal-functions (arg)
+  "Advise terminal functions to run `helm-mt' instead when called interactively.
+If ARG is t, then activate the advice; otherwise, remove it."
+  (dolist (fun (list 'term 'shell))
+    (if arg
+        (advice-add fun :around #'helm-mt/reroute-function)
+      (advice-remove fun #'helm-mt/reroute-function))))
+
+;;;###autoload
+(defun helm-mt (&optional prefix)
   "Custom helm buffer for terminals only.
 PREFIX is passed on to `helm-mt/term-source-terminal-not-found'."
   (interactive "P")


### PR DESCRIPTION
I created a trimmed down version of `helm-mt`to make it a more light-weight wrapper around `multi-term`s existing functionality.

~~Note that this is somewhat opinionated as it drops support for creation of terminals in `shell-mode`. I realize that this can be considered a show-stopper by some. That said, if `shell-mode` support is desired, shouldn't it rather go into `multi-term`?~~
- Use existing `multi-term-buffer-list` variable to determine available term buffers.
- Relay prefix argument to `multi-term` (to choose shell), if any.
- If no name is given when creating a new term buffer, default to current working directory of the launched process.
- As a consequence of ^^, remove `C-c n` keybinding and related  "auto-terminal" code.
- Wire `M-D` to delete marked items in Helm  buffer (same as `helm-buffer-list`).

Let me know what you think -- thanks!
